### PR TITLE
Subtitle was overlaps on iOS. Now it's not anymore

### DIFF
--- a/Chameleon.Core/Pages/PlayerPage.xaml
+++ b/Chameleon.Core/Pages/PlayerPage.xaml
@@ -18,8 +18,8 @@
     <NavigationPage.TitleView>
         <Grid>
             <Grid.RowDefinitions>
-                <RowDefinition Height="28"/>
-                <RowDefinition Height="28"/>
+                <RowDefinition Height="23"/>
+                <RowDefinition Height="23"/>
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
bug

### :arrow_heading_down: What is the current behavior?
Subtitle was overlapping 

### :new: What is the new behavior (if this is a feature change)?
Subtitle is not overlapped anymore

### :boom: Does this PR introduce a breaking change?
no

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
