### PR TITLE
Setting Page layout

### DIFF
--- a/Chameleon.Core/Pages/SettingsPage.xaml
+++ b/Chameleon.Core/Pages/SettingsPage.xaml
@@ -16,7 +16,10 @@
     
     <ContentPage.Content>
         <ScrollView>
-            <StackLayout>
+            <StackLayout VerticalOptions="End">
+
+                <Image Source="powered_by_baseflow_logo" Margin="10,0,0,10" HorizontalOptions="Start"/>
+                <Label mvx:La.ng="Text PowerdByText" WidthRequest="200" HeightRequest="140" FontFamily="FiraSans#400" FontSize="12" FontAttributes="None" TextColor="#FFE3E5F6" LineHeight="1.3" Margin="10,0,10,0" />
                 <Button mvx:La.ng="Text FindUsOnGithub" mvx:Bi.nd="Command GithubCommand" Style="{StaticResource PrimaryButton}"/>
                 <Button mvx:La.ng="Text VisitBaseflow" mvx:Bi.nd="Command BaseflowCommand" Style="{StaticResource PrimaryButton}" />
             </StackLayout>

--- a/Chameleon.Core/Resources/en/SettingsViewModel.json
+++ b/Chameleon.Core/Resources/en/SettingsViewModel.json
@@ -1,5 +1,6 @@
 ﻿{
   "Title": "Settings",
+    "PowerdByText": "This app showcases the possibilities of the Xamarin Media Manager plugin, developed by Baseflow. This plugin is available as open source project on Github.\n\nNeed help  with integrating functionalities within your own apps? Contact us at hello@baseflow.com",
   "FindUsOnGithub": "Find us on Github",
   "VisitBaseflow":  "Visit baseflow.com"
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
feature

### :arrow_heading_down: What is the current behavior?
Only two buttons for settings page

### :new: What is the new behavior (if this is a feature change)?
Layout more like zeplin. Without the list, with the tree items. 

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
See settings page

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
