### PR TITLE
added custom render for SeparatorColor to change color

### DIFF
--- a/Chameleon.Android/Chameleon.Android.csproj
+++ b/Chameleon.Android/Chameleon.Android.csproj
@@ -124,6 +124,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Setup.cs" />
     <Compile Include="CustomRenderers\MySearchBarRenderer.cs" />
+    <Compile Include="CustomRenderers\ColoredTableViewRenderer.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\AboutResources.txt" />

--- a/Chameleon.Android/CustomRenderers/ColoredTableViewRenderer.cs
+++ b/Chameleon.Android/CustomRenderers/ColoredTableViewRenderer.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.ComponentModel;
+using Android.Content;
+using Android.Graphics.Drawables;
+using Chameleon.Android.CustomRenderers;
+using Chameleon.Core;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.Android;
+
+[assembly: ExportRenderer(typeof(ColoredTableView), typeof(ColoredTableViewRenderer))]
+namespace Chameleon.Android.CustomRenderers
+{
+    public class ColoredTableViewRenderer : TableViewRenderer
+    {
+        public ColoredTableViewRenderer(Context context) : base(context)
+        {
+        }
+
+        protected override void OnElementChanged(ElementChangedEventArgs<TableView> e)
+        {
+            base.OnElementChanged(e);
+            if (Control == null)
+                return;
+
+            var listView = Control as global::Android.Widget.ListView;
+            var coloredTableView = (ColoredTableView)Element;
+            listView.Divider = new ColorDrawable(coloredTableView.SeparatorColor.ToAndroid());
+            listView.DividerHeight = 3;
+        }
+
+        protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            base.OnElementPropertyChanged(sender, e);
+            if (e.PropertyName == "SeparatorColor")
+            {
+                var listView = Control as global::Android.Widget.ListView;
+                var coloredTableView = (ColoredTableView)Element;
+                listView.Divider = new ColorDrawable(coloredTableView.SeparatorColor.ToAndroid());
+            }
+        }
+    }
+}

--- a/Chameleon.Core/ColoredTableView.cs
+++ b/Chameleon.Core/ColoredTableView.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Xamarin.Forms;
+
+namespace Chameleon.Core
+{
+    public partial class ColoredTableView : TableView
+    {
+        public static BindableProperty SeparatorColorProperty = BindableProperty.Create("SeparatorColor", typeof(Color), typeof(ColoredTableView), Color.White);
+        public Color SeparatorColor
+        {
+            get
+            {
+                return (Color)GetValue(SeparatorColorProperty);
+            }
+            set
+            {
+                SetValue(SeparatorColorProperty, value);
+            }
+        }
+        public ColoredTableView()
+        {
+            //InitializeComponent();
+        }
+
+       
+    }
+}

--- a/Chameleon.Core/Pages/SettingsPage.xaml
+++ b/Chameleon.Core/Pages/SettingsPage.xaml
@@ -8,15 +8,18 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:viewModels="clr-namespace:Chameleon.Core.ViewModels;assembly=Chameleon.Core"
     xmlns:templates="clr-namespace:Chameleon.Core.Templates;assembly=Chameleon.Core"
+    xmlns:coloredTableView="clr-namespace:Chameleon.Core;assembly=Chameleon.Core"
     mc:Ignorable="d"
     x:TypeArguments="viewModels:SettingsViewModel"
     x:Class="Chameleon.Core.Views.SettingsPage"
     mvx:La.ng="Title Title" >
     
     <ContentPage.Content>
-       <TableView Intent="Settings"
+       <coloredTableView:ColoredTableView
+                  Intent="Settings"
                   BackgroundColor="{StaticResource BackgroundColor}"
-                  HasUnevenRows="True">
+                  HasUnevenRows="True"
+                  SeparatorColor="#30313C">
           <TableRoot>
               <TableSection>
                   <!--
@@ -75,6 +78,6 @@
                   </ViewCell>
               </TableSection>
           </TableRoot>
-        </TableView>
+        </coloredTableView:ColoredTableView>
     </ContentPage.Content>
 </core:MvxContentPage>

--- a/Chameleon.iOS/Chameleon.iOS.csproj
+++ b/Chameleon.iOS/Chameleon.iOS.csproj
@@ -77,6 +77,7 @@
     <None Include="Info.plist" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="CustomRenderers\MaterialSearchBarRenderer.cs" />
+    <Compile Include="CustomRenderers\ColoredTableViewRenderer.cs" />
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="Resources\LaunchScreen.storyboard" />

--- a/Chameleon.iOS/CustomRenderers/ColoredTableViewRenderer.cs
+++ b/Chameleon.iOS/CustomRenderers/ColoredTableViewRenderer.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.ComponentModel;
+using Chameleon.Core;
+using Chameleon.iOS.CustomRenderers;
+using UIKit;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.iOS;
+
+[assembly: ExportRenderer(typeof(ColoredTableView), typeof(ColoredTableViewRenderer))]
+namespace Chameleon.iOS.CustomRenderers
+{
+    public class ColoredTableViewRenderer : TableViewRenderer
+    {
+        protected override void OnElementChanged(ElementChangedEventArgs<TableView> e)
+        {
+            base.OnElementChanged(e);
+            if (Control == null)
+                return;
+
+            var tableView = Control as UITableView;
+            var coloredTableView = Element as ColoredTableView;
+            tableView.SeparatorColor = coloredTableView.SeparatorColor.ToUIColor();
+        }
+
+        protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            base.OnElementPropertyChanged(sender, e);
+            if (e.PropertyName == "SeparatorColor")
+            {
+                var tableView = Control as UITableView;
+                var coloredTableView = Element as ColoredTableView;
+
+                tableView.SeparatorColor = coloredTableView.SeparatorColor.ToUIColor();
+            }
+        }
+    }
+}
+
+


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
White saperators in iOS in TableView Settingpage

### :new: What is the new behavior (if this is a feature change)?
Color of background for separetors in iOS and Android for TableView Settings

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop
