### PR TITLE
Binding text soon

### DIFF
--- a/Chameleon.Core/Pages/ProvidersPage.xaml
+++ b/Chameleon.Core/Pages/ProvidersPage.xaml
@@ -12,7 +12,8 @@
     xmlns:pan="clr-namespace:Xamarin.Forms.PancakeView;assembly=Xamarin.Forms.PancakeView"
     mc:Ignorable="d"
     x:TypeArguments="viewModels:ProvidersViewModel"
-    x:Class="Chameleon.Core.Views.ProvidersPage">
+    x:Class="Chameleon.Core.Views.ProvidersPage"
+    x:Name="providerPage">
 
     <NavigationPage.TitleView>
         <StackLayout Orientation="Horizontal" VerticalOptions="Center" HorizontalOptions="Center" Spacing="10" HeightRequest="30">
@@ -93,7 +94,7 @@
                                 iOS="False"
                                 Android="True" />
                                 </pan:PancakeView.HasShadow>
-                                <Label Text="Soon" Style="{StaticResource Data1}" />
+                                <Label Text="{Binding Source={x:Reference Name=providerPage}, Path=BindingContext.DataContext.SoonText}" Style="{StaticResource Data1}" />
                             </pan:PancakeView>
                             <Image Source="disclosure_button" HorizontalOptions="End" BackgroundColor="Transparent" Grid.Column="2"/>
                         </Grid>

--- a/Chameleon.Core/Resources/en/ProvidersViewModel.json
+++ b/Chameleon.Core/Resources/en/ProvidersViewModel.json
@@ -2,5 +2,5 @@
     "Title": "Providers",
     "Recommended": "Recommended",
     "Sources": "All sources",
-    "Soon": "Soon"
+    "Soon": "SOON"
 }

--- a/Chameleon.Core/ViewModels/ProvidersViewModel.cs
+++ b/Chameleon.Core/ViewModels/ProvidersViewModel.cs
@@ -23,6 +23,15 @@ namespace Chameleon.Core.ViewModels
             set => SetProperty(ref _selectedItem, value);
         }
 
+        public string SoonText
+        {
+            get
+            {
+                var text = GetText("Soon");
+                return text;
+            }
+        }
+
         private IList<Provider> _recommendedProviders;
         public IList<Provider> RecommendedProviders
         {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
bug

### :arrow_heading_down: What is the current behavior?
Text 'Soon' was not binded

### :new: What is the new behavior (if this is a feature change)?
Text 'soon' is binded

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines 
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop
