### PR TITLE
miniplayer

### DIFF
--- a/Chameleon.Core/Chameleon.Core.csproj
+++ b/Chameleon.Core/Chameleon.Core.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="Acr.UserDialogs" Version="7.0.25" />
     <PackageReference Include="MonkeyCache.LiteDB" Version="1.3.0" />
     <PackageReference Include="Xamarin.Forms.PancakeView" Version="1.1.5" />
+    <PackageReference Include="Xamarin.Forms.DebugRainbows" Version="1.0.16" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Chameleon.Core/Pages/HomePage.xaml
+++ b/Chameleon.Core/Pages/HomePage.xaml
@@ -15,7 +15,6 @@
     x:TypeArguments="viewModels:HomeViewModel"
     x:Class="Chameleon.Core.Views.HomePage"
     x:Name="homePage"
-    ios:Page.UseSafeArea="True"
     mvx:La.ng="Title Title">
 
     <Grid>
@@ -156,7 +155,8 @@
                     Margin="24,0" />
             </StackLayout>
         </ScrollView>
-        <views:MiniPlayerView Grid.Row="1"/>
+        <views:MiniPlayerView Grid.Row="1"
+                              IsVisible="{Binding Source={x:Reference Name=homePage}, Path=BindingContext.DataContext.IsPlaying}" />
     </Grid>
 
 </core:MvxContentPage>

--- a/Chameleon.Core/Pages/HomePage.xaml
+++ b/Chameleon.Core/Pages/HomePage.xaml
@@ -155,7 +155,8 @@
             </StackLayout>
         </ScrollView>
         <views:MiniPlayerView Grid.Row="1"
-                              ViewModel="{Binding MiniPlayerViewModel}" />
+                              ViewModel="{Binding MiniPlayerViewModel}"
+                              IsVisible="{Binding Source={x:Reference homePage}, Path=BindingContext.DataContext.IsPlaying}"/>
     </Grid>
 
 </core:MvxContentPage>

--- a/Chameleon.Core/Pages/HomePage.xaml
+++ b/Chameleon.Core/Pages/HomePage.xaml
@@ -6,14 +6,13 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:d="http://xamarin.com/schemas/2014/forms/design"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core"
     xmlns:templates="clr-namespace:Chameleon.Core.Templates;assembly=Chameleon.Core"
     xmlns:pan="clr-namespace:Xamarin.Forms.PancakeView;assembly=Xamarin.Forms.PancakeView"
     xmlns:viewModels="clr-namespace:Chameleon.Core.ViewModels;assembly=Chameleon.Core"
     xmlns:views="clr-namespace:Chameleon.Core.Views;assembly=Chameleon.Core"
     mc:Ignorable="d"
     x:TypeArguments="viewModels:HomeViewModel"
-    x:Class="Chameleon.Core.Views.HomePage"
+    x:Class="Chameleon.Core.Pages.HomePage"
     x:Name="homePage"
     mvx:La.ng="Title Title">
 
@@ -156,7 +155,7 @@
             </StackLayout>
         </ScrollView>
         <views:MiniPlayerView Grid.Row="1"
-                              IsVisible="{Binding Source={x:Reference Name=homePage}, Path=BindingContext.DataContext.IsPlaying}" />
+                              ViewModel="{Binding MiniPlayerViewModel}" />
     </Grid>
 
 </core:MvxContentPage>

--- a/Chameleon.Core/Pages/HomePage.xaml
+++ b/Chameleon.Core/Pages/HomePage.xaml
@@ -9,143 +9,148 @@
     xmlns:templates="clr-namespace:Chameleon.Core.Templates;assembly=Chameleon.Core"
     xmlns:pan="clr-namespace:Xamarin.Forms.PancakeView;assembly=Xamarin.Forms.PancakeView"
     xmlns:viewModels="clr-namespace:Chameleon.Core.ViewModels;assembly=Chameleon.Core"
+    xmlns:views="clr-namespace:Chameleon.Core.Views;assembly=Chameleon.Core"
     mc:Ignorable="d"
     x:TypeArguments="viewModels:HomeViewModel"
     x:Class="Chameleon.Core.Views.HomePage"
     x:Name="homePage"
     mvx:La.ng="Title Title">
 
-    <ScrollView>
-        <StackLayout>
-            <Label
-                mvx:La.ng="Text Recent"
-                IsVisible="{Binding HasRecent}"
-                Style="{StaticResource Header1}"
-                Margin="24,0" />
-            <CollectionView
-                x:Name="RecentCollectionView"
-                SelectionMode="Single"
-                IsVisible="{Binding HasRecent}"
-                mvx:Bi.nd="ItemsSource RecentlyPlayedItems;
+    <StackLayout Spacing="0">
+        <ScrollView Padding="0,0,0,100">
+            <StackLayout>
+                <Label
+                    mvx:La.ng="Text Recent"
+                    IsVisible="{Binding HasRecent}"
+                    Style="{StaticResource Header1}"
+                    Margin="24,0" />
+                <CollectionView
+                    x:Name="RecentCollectionView"
+                    SelectionMode="Single"
+                    IsVisible="{Binding HasRecent}"
+                    mvx:Bi.nd="ItemsSource RecentlyPlayedItems;
                     SelectionChangedCommand PlayerCommand;
                     SelectionChangedCommandParameter SelectedMediaItem;
                     SelectedItem SelectedMediaItem"
-                HeightRequest="250">
+                    HeightRequest="250">
 
-                <CollectionView.ItemsLayout>
-                    <GridItemsLayout
-                        Orientation="Horizontal" />
-                </CollectionView.ItemsLayout>
+                    <CollectionView.ItemsLayout>
+                        <GridItemsLayout
+                            Orientation="Horizontal" />
+                    </CollectionView.ItemsLayout>
 
-                <CollectionView.EmptyView>
-                    <StackLayout>
-                        <ActivityIndicator
-                            Color="DimGray"
-                            IsRunning="{Binding IsLoading}"
-                            HeightRequest="50" />
-                    </StackLayout>
-                </CollectionView.EmptyView>
+                    <CollectionView.EmptyView>
+                        <StackLayout>
+                            <ActivityIndicator
+                                Color="DimGray"
+                                IsRunning="{Binding IsLoading}"
+                                HeightRequest="50" />
+                        </StackLayout>
+                    </CollectionView.EmptyView>
 
-                <CollectionView.ItemTemplate>
-                    <DataTemplate>
-                        <templates:HorizontalMediaItemsTemplate />
-                    </DataTemplate>
-                </CollectionView.ItemTemplate>
-            </CollectionView>
-            <StackLayout
-                Spacing="0"
-                Orientation="Horizontal"
-                Padding="24,0"
-                Margin="0,24,0,0">
-                <Label
-                    mvx:La.ng="Text Playlists"
-                    Style="{StaticResource Header1}"
-                    HorizontalOptions="Start"
-                    VerticalTextAlignment="Center" />
+                    <CollectionView.ItemTemplate>
+                        <DataTemplate>
+                            <templates:HorizontalMediaItemsTemplate />
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+                </CollectionView>
+                <StackLayout
+                    Spacing="0"
+                    Orientation="Horizontal"
+                    Padding="24,0"
+                    Margin="0,24,0,0">
+                    <Label
+                        mvx:La.ng="Text Playlists"
+                        Style="{StaticResource Header1}"
+                        HorizontalOptions="Start"
+                        VerticalTextAlignment="Center" />
+                    <Button
+                        mvx:La.ng="Text AllPlaylists"
+                        mvx:Bi.nd="Command OpenPlaylistOverviewCommand"
+                        Style="{StaticResource SecondaryButton}"
+                        HorizontalOptions="EndAndExpand"
+                        Padding="19,0" />
+                </StackLayout>
+                <CollectionView
+                    x:Name="PlaylistsCollectionView"
+                    SelectionMode="Single"
+                    mvx:Bi.nd="ItemsSource Playlists; SelectionChangedCommand OpenPlaylistCommand; SelectionChangedCommandParameter SelectedPlaylist; SelectedItem SelectedPlaylist"
+                    HeightRequest="250">
+
+                    <CollectionView.ItemsLayout>
+                        <GridItemsLayout
+                            Orientation="Horizontal" />
+                    </CollectionView.ItemsLayout>
+
+                    <CollectionView.EmptyView>
+                        <Grid Padding="24,0">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="154" />
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="154" />
+                                <RowDefinition Height="auto" />
+                            </Grid.RowDefinitions>
+                            <pan:PancakeView
+                                CornerRadius="8"
+                                WidthRequest="154"
+                                HeightRequest="154"
+                                IsClippedToBounds="True"
+                                HorizontalOptions="FillAndExpand"
+                                BackgroundColor="#FF252525"
+                                VerticalOptions="FillAndExpand"
+                                Elevation="2">
+                                <pan:PancakeView.HasShadow>
+                                    <OnPlatform
+                                        x:TypeArguments="x:Boolean"
+                                        iOS="False"
+                                        Android="True" />
+                                </pan:PancakeView.HasShadow>
+                                <AbsoluteLayout>
+                                    <ImageButton
+                                        AbsoluteLayout.LayoutFlags="All"
+                                        AbsoluteLayout.LayoutBounds=".5,.5,1,1"
+                                        Padding="50"
+                                        BackgroundColor="#FF252525"
+                                        Command="{Binding Source={x:Reference Name=homePage}, Path=BindingContext.DataContext.AddPlaylistCommand}"
+                                        Source="icon_plus" />
+                                    <Label
+                                        Text="{Binding Source={x:Reference Name=homePage}, Path=BindingContext.DataContext.AddPlaylistLabel}"
+                                        FontSize="14"
+                                        FontAttributes="Bold"
+                                        HorizontalTextAlignment="Center"
+                                        VerticalTextAlignment="End"
+                                        AbsoluteLayout.LayoutFlags="PositionProportional"
+                                        AbsoluteLayout.LayoutBounds=".5,.9,AutoSize,AutoSize" />
+                                </AbsoluteLayout>
+                            </pan:PancakeView>
+                        </Grid>
+                    </CollectionView.EmptyView>
+
+                    <CollectionView.ItemTemplate>
+                        <DataTemplate>
+                            <templates:HorizontalMediaItemsTemplate />
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+                </CollectionView>
                 <Button
-                    mvx:La.ng="Text AllPlaylists"
-                    mvx:Bi.nd="Command OpenPlaylistOverviewCommand"
-                    Style="{StaticResource SecondaryButton}"
-                    HorizontalOptions="EndAndExpand"
-                    Padding="19,0" />
+                    mvx:La.ng="Text PlayDevice"
+                    mvx:Bi.nd="Command OpenFileCommand"
+                    Style="{StaticResource PrimaryButton}"
+                    Margin="24,0" />
+                <Button
+                    mvx:La.ng="Text OpenUrl"
+                    mvx:Bi.nd="Command OpenUrlCommand"
+                    Style="{StaticResource PrimaryButton}"
+                    Margin="24,0" />
+                <Button
+                    mvx:La.ng="Text Player"
+                    mvx:Bi.nd="Command PlayerCommand"
+                    Style="{StaticResource PrimaryButton}"
+                    Margin="24,0" />
             </StackLayout>
-            <CollectionView
-                x:Name="PlaylistsCollectionView"
-                SelectionMode="Single"
-                mvx:Bi.nd="ItemsSource Playlists; SelectionChangedCommand OpenPlaylistCommand; SelectionChangedCommandParameter SelectedPlaylist; SelectedItem SelectedPlaylist"
-                HeightRequest="250">
+        </ScrollView>
+        <views:MiniPlayerView/>
+    </StackLayout>
 
-                <CollectionView.ItemsLayout>
-                    <GridItemsLayout
-                        Orientation="Horizontal" />
-                </CollectionView.ItemsLayout>
-
-                <CollectionView.EmptyView>
-                    <Grid Padding="24,0">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="154" />
-                        </Grid.ColumnDefinitions>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="154" />
-                            <RowDefinition Height="auto" />
-                        </Grid.RowDefinitions>
-                        <pan:PancakeView
-                            CornerRadius="8"
-                            WidthRequest="154"
-                            HeightRequest="154"
-                            IsClippedToBounds="True"
-                            HorizontalOptions="FillAndExpand"
-                            BackgroundColor="#FF252525"
-                            VerticalOptions="FillAndExpand"
-                            Elevation="2">
-                            <pan:PancakeView.HasShadow>
-                                <OnPlatform
-                                    x:TypeArguments="x:Boolean"
-                                    iOS="False"
-                                    Android="True" />
-                            </pan:PancakeView.HasShadow>
-                            <AbsoluteLayout>
-                                <ImageButton
-                                    AbsoluteLayout.LayoutFlags="All"
-                                    AbsoluteLayout.LayoutBounds=".5,.5,1,1"
-                                    Padding="50"
-                                    BackgroundColor="#FF252525"
-                                    Command="{Binding Source={x:Reference Name=homePage}, Path=BindingContext.DataContext.AddPlaylistCommand}"
-                                    Source="icon_plus" />
-                                <Label
-                                    Text="{Binding Source={x:Reference Name=homePage}, Path=BindingContext.DataContext.AddPlaylistLabel}"
-                                    FontSize="14"
-                                    FontAttributes="Bold"
-                                    HorizontalTextAlignment="Center"
-                                    VerticalTextAlignment="End"
-                                    AbsoluteLayout.LayoutFlags="PositionProportional"
-                                    AbsoluteLayout.LayoutBounds=".5,.9,AutoSize,AutoSize" />
-                            </AbsoluteLayout>
-                        </pan:PancakeView>
-                    </Grid>
-                </CollectionView.EmptyView>
-
-                <CollectionView.ItemTemplate>
-                    <DataTemplate>
-                        <templates:HorizontalMediaItemsTemplate />
-                    </DataTemplate>
-                </CollectionView.ItemTemplate>
-            </CollectionView>
-            <Button
-                mvx:La.ng="Text PlayDevice"
-                mvx:Bi.nd="Command OpenFileCommand"
-                Style="{StaticResource PrimaryButton}"
-                Margin="24,0" />
-            <Button
-                mvx:La.ng="Text OpenUrl"
-                mvx:Bi.nd="Command OpenUrlCommand"
-                Style="{StaticResource PrimaryButton}"
-                Margin="24,0" />
-            <Button
-                mvx:La.ng="Text Player"
-                mvx:Bi.nd="Command PlayerCommand"
-                Style="{StaticResource PrimaryButton}"
-                Margin="24,0" />
-        </StackLayout>
-    </ScrollView>
 </core:MvxContentPage>

--- a/Chameleon.Core/Pages/HomePage.xaml
+++ b/Chameleon.Core/Pages/HomePage.xaml
@@ -6,6 +6,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:d="http://xamarin.com/schemas/2014/forms/design"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core"
     xmlns:templates="clr-namespace:Chameleon.Core.Templates;assembly=Chameleon.Core"
     xmlns:pan="clr-namespace:Xamarin.Forms.PancakeView;assembly=Xamarin.Forms.PancakeView"
     xmlns:viewModels="clr-namespace:Chameleon.Core.ViewModels;assembly=Chameleon.Core"
@@ -14,10 +15,15 @@
     x:TypeArguments="viewModels:HomeViewModel"
     x:Class="Chameleon.Core.Views.HomePage"
     x:Name="homePage"
+    ios:Page.UseSafeArea="True"
     mvx:La.ng="Title Title">
 
-    <StackLayout Spacing="0">
-        <ScrollView Padding="0,0,0,100">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <ScrollView>
             <StackLayout>
                 <Label
                     mvx:La.ng="Text Recent"
@@ -150,7 +156,7 @@
                     Margin="24,0" />
             </StackLayout>
         </ScrollView>
-        <views:MiniPlayerView VerticalOptions="End" />
-    </StackLayout>
+        <views:MiniPlayerView Grid.Row="1"/>
+    </Grid>
 
 </core:MvxContentPage>

--- a/Chameleon.Core/Pages/HomePage.xaml
+++ b/Chameleon.Core/Pages/HomePage.xaml
@@ -150,7 +150,7 @@
                     Margin="24,0" />
             </StackLayout>
         </ScrollView>
-        <views:MiniPlayerView VerticalOptions="End" />
+        <views:MiniPlayerView/>
     </StackLayout>
 
 </core:MvxContentPage>

--- a/Chameleon.Core/Pages/HomePage.xaml
+++ b/Chameleon.Core/Pages/HomePage.xaml
@@ -150,7 +150,7 @@
                     Margin="24,0" />
             </StackLayout>
         </ScrollView>
-        <views:MiniPlayerView/>
+        <views:MiniPlayerView VerticalOptions="End" />
     </StackLayout>
 
 </core:MvxContentPage>

--- a/Chameleon.Core/Pages/HomePage.xaml.cs
+++ b/Chameleon.Core/Pages/HomePage.xaml.cs
@@ -4,7 +4,7 @@ using MvvmCross.Forms.Presenters.Attributes;
 using MvvmCross.Forms.Views;
 using Xamarin.Forms;
 
-namespace Chameleon.Core.Views
+namespace Chameleon.Core.Pages
 {
     // Learn more about making custom code visible in the Xamarin.Forms previewer
     // by visiting https://aka.ms/xamarinforms-previewer

--- a/Chameleon.Core/Pages/RootPage.xaml
+++ b/Chameleon.Core/Pages/RootPage.xaml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <core:MvxTabbedPage
-    xmlns:core="clr-namespace:MvvmCross.Forms.Views;assembly=MvvmCross.Forms" 
+    xmlns:core="clr-namespace:MvvmCross.Forms.Views;assembly=MvvmCross.Forms"
     xmlns:mvx="clr-namespace:MvvmCross.Forms.Bindings;assembly=MvvmCross.Forms"
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
@@ -8,22 +8,27 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:viewModels="clr-namespace:Chameleon.Core.ViewModels;assembly=Chameleon.Core"
     xmlns:local="clr-namespace:Chameleon.Core;assembly=Chameleon.Core"
+    xmlns:views="clr-namespace:Chameleon.Core.Views;assembly=Chameleon.Core"
     xmlns:android="clr-namespace:Xamarin.Forms.PlatformConfiguration.AndroidSpecific;assembly=Xamarin.Forms.Core"
     mc:Ignorable="d"
     x:TypeArguments="viewModels:RootViewModel"
     x:Class="Chameleon.Core.Views.RootPage"
     IconImageSource="chameleon_logo.png"
-    android:TabbedPage.IsSwipePagingEnabled="False" 
+    android:TabbedPage.IsSwipePagingEnabled="False"
     android:TabbedPage.ToolbarPlacement="Bottom">
-    
+
     <local:Views.HomePage />
     <local:Views.BrowsePage />
     <local:Views.MePage />
 
     <NavigationPage.TitleView>
-        <StackLayout Orientation="Horizontal" VerticalOptions="Center" HorizontalOptions="Center" Spacing="10" HeightRequest="30">
-            <Image Source="chameleon_logo"/>
+        <StackLayout Orientation="Horizontal"
+                     VerticalOptions="Center"
+                     HorizontalOptions="Center"
+                     Spacing="10"
+                     HeightRequest="30">
+            <Image Source="chameleon_logo" />
         </StackLayout>
     </NavigationPage.TitleView>
-    
+
 </core:MvxTabbedPage>

--- a/Chameleon.Core/ViewModels/HomeViewModel.cs
+++ b/Chameleon.Core/ViewModels/HomeViewModel.cs
@@ -126,6 +126,18 @@ namespace Chameleon.Core.ViewModels
             _isInitialized = true;
         }
 
+        public override void ViewAppeared()
+        {
+            base.ViewAppeared();
+            MiniPlayerViewModel.ViewAppeared();
+        }
+
+        public override void ViewDisappeared()
+        {
+            base.ViewDisappeared();
+            MiniPlayerViewModel.ViewDisappeared();
+        }
+
         public override async Task ReloadData(bool forceReload = false)
         {
             IsLoading = true;

--- a/Chameleon.Core/ViewModels/HomeViewModel.cs
+++ b/Chameleon.Core/ViewModels/HomeViewModel.cs
@@ -4,6 +4,7 @@ using Acr.UserDialogs;
 using Chameleon.Services.Services;
 using MediaManager;
 using MediaManager.Library;
+using MvvmCross;
 using MvvmCross.Commands;
 using MvvmCross.Logging;
 using MvvmCross.Navigation;
@@ -45,6 +46,16 @@ namespace Chameleon.Core.ViewModels
         {
             get => _isPlaying;
             set => SetProperty(ref _isPlaying, value);
+        }
+
+        private MiniPlayerViewModel _miniPlayerViewModel;
+        public MiniPlayerViewModel MiniPlayerViewModel
+        {
+            get => _miniPlayerViewModel;
+            set
+            {
+                SetProperty(ref _miniPlayerViewModel, value);
+            }
         }
 
         private MvxObservableCollection<IPlaylist> _playlists = new MvxObservableCollection<IPlaylist>();
@@ -95,6 +106,12 @@ namespace Chameleon.Core.ViewModels
 
         private IMvxAsyncCommand _openPlaylistOverviewCommand;
         public IMvxAsyncCommand OpenPlaylistOverviewCommand => _openPlaylistOverviewCommand ?? (_openPlaylistOverviewCommand = new MvxAsyncCommand(() => NavigationService.Navigate<PlaylistOverviewViewModel>()));
+
+        public override void Prepare()
+        {
+            var vm = Mvx.IoCProvider.Resolve<IMvxViewModelLoader>().LoadViewModel(MvxViewModelRequest<MiniPlayerViewModel>.GetDefaultRequest(), null) as MiniPlayerViewModel;
+            MiniPlayerViewModel = vm;
+        }
 
         public override async void ViewAppearing()
         {

--- a/Chameleon.Core/ViewModels/HomeViewModel.cs
+++ b/Chameleon.Core/ViewModels/HomeViewModel.cs
@@ -116,10 +116,13 @@ namespace Chameleon.Core.ViewModels
         public override async void ViewAppearing()
         {
             base.ViewAppearing();
+            MiniPlayerViewModel.ViewAppearing();
+
             if (_isInitialized)
                 await ReloadData().ConfigureAwait(false);
 
             IsPlaying = MediaManager.MediaQueue.Count > 0;
+
             _isInitialized = true;
         }
 

--- a/Chameleon.Core/ViewModels/HomeViewModel.cs
+++ b/Chameleon.Core/ViewModels/HomeViewModel.cs
@@ -18,11 +18,15 @@ namespace Chameleon.Core.ViewModels
         private readonly IPlaylistService _playlistService;
         private readonly IBrowseService _browseService;
 
-        public HomeViewModel(IMvxLogProvider logProvider, IMvxNavigationService navigationService, IUserDialogs userDialogs, IPlaylistService playlistService, IBrowseService browseService) : base(logProvider, navigationService)
+        public IMediaManager MediaManager { get; }
+
+        public HomeViewModel(IMvxLogProvider logProvider, IMvxNavigationService navigationService, IUserDialogs userDialogs, IPlaylistService playlistService, IBrowseService browseService, IMediaManager mediaManager) : base(logProvider, navigationService)
         {
             _userDialogs = userDialogs ?? throw new ArgumentNullException(nameof(userDialogs));
             _playlistService = playlistService ?? throw new ArgumentNullException(nameof(playlistService));
             _browseService = browseService ?? throw new ArgumentNullException(nameof(browseService));
+
+            MediaManager = mediaManager ?? throw new ArgumentNullException(nameof(mediaManager));
         }
 
         private bool _isInitialized;
@@ -34,6 +38,13 @@ namespace Chameleon.Core.ViewModels
                 var text = GetText("AddPlaylist");
                 return text;
             }
+        }
+
+        private bool _isPlaying;
+        public bool IsPlaying
+        {
+            get => _isPlaying;
+            set => SetProperty(ref _isPlaying, value);
         }
 
         private MvxObservableCollection<IPlaylist> _playlists = new MvxObservableCollection<IPlaylist>();
@@ -90,6 +101,8 @@ namespace Chameleon.Core.ViewModels
             base.ViewAppearing();
             if (_isInitialized)
                 await ReloadData().ConfigureAwait(false);
+
+            IsPlaying = MediaManager.MediaQueue.Count > 0;
             _isInitialized = true;
         }
 

--- a/Chameleon.Core/ViewModels/MiniPlayerViewModel.cs
+++ b/Chameleon.Core/ViewModels/MiniPlayerViewModel.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Threading.Tasks;
 using MediaManager;
+using MvvmCross.Commands;
 using MvvmCross.Logging;
 using MvvmCross.Navigation;
 
@@ -13,6 +15,19 @@ namespace Chameleon.Core.ViewModels
             : base(logProvider, navigationService)
         {
             MediaManager = mediaManager ?? throw new ArgumentNullException(nameof(mediaManager));
-        }   
+        }
+
+        public override Task Initialize()
+        {
+            return base.Initialize();
+        }
+
+        private IMvxAsyncCommand _playpauseCommand;
+        public IMvxAsyncCommand PlayPauseCommand => _playpauseCommand ?? (_playpauseCommand = new MvxAsyncCommand(PlayPause));
+
+        private Task PlayPause()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/Chameleon.Core/ViewModels/MiniPlayerViewModel.cs
+++ b/Chameleon.Core/ViewModels/MiniPlayerViewModel.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using MediaManager;
+using MvvmCross.Logging;
+using MvvmCross.Navigation;
+
+namespace Chameleon.Core.ViewModels
+{
+    public class MiniPlayerViewModel : BaseViewModel
+    {
+        public IMediaManager MediaManager { get; }
+
+        public MiniPlayerViewModel(IMvxLogProvider logProvider, IMvxNavigationService navigationService, IMediaManager mediaManager)
+            : base(logProvider, navigationService)
+        {
+            MediaManager = mediaManager ?? throw new ArgumentNullException(nameof(mediaManager));
+        }   
+    }
+}

--- a/Chameleon.Core/Views/MiniPlayerView.xaml
+++ b/Chameleon.Core/Views/MiniPlayerView.xaml
@@ -6,6 +6,7 @@
                      xmlns:d="http://xamarin.com/schemas/2014/forms/design"
                      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                      xmlns:viewModels="clr-namespace:Chameleon.Core.ViewModels;assembly=Chameleon.Core"
+                     x:TypeArguments="viewModels:MiniPlayerViewModel"
                      mc:Ignorable="d"
                      x:Class="Chameleon.Core.Views.MiniPlayerView">
 
@@ -64,6 +65,7 @@
                          HeightRequest="35"
                          WidthRequest="35"
                          HorizontalOptions="Center"
+                         Command="{Binding PlayPauseCommand}"
                          Source="playback_controls_play_button" />
             <ImageButton Grid.Row="2"
                          Grid.Column="4"

--- a/Chameleon.Core/Views/MiniPlayerView.xaml
+++ b/Chameleon.Core/Views/MiniPlayerView.xaml
@@ -83,7 +83,7 @@
                      Grid.ColumnSpan="7"
                      Color="Black"
                      Margin="0,12,0,.5"
-                     HeightRequest=".5"/>
+                     HeightRequest=".5" />
         </Grid>
     </ContentView.Content>
 </ContentView>

--- a/Chameleon.Core/Views/MiniPlayerView.xaml
+++ b/Chameleon.Core/Views/MiniPlayerView.xaml
@@ -81,9 +81,14 @@
                          Source="icon_more" />
             <BoxView Grid.Row="3"
                      Grid.ColumnSpan="7"
-                     Color="Black"
                      Margin="0,12,0,.5"
-                     HeightRequest=".5" />
+                     HeightRequest=".5">
+                <BoxView.Color>
+                    <OnPlatform x:TypeArguments="Color"
+                                iOS="Transparent"
+                                Android="Black" />
+                </BoxView.Color>
+            </BoxView>
         </Grid>
     </ContentView.Content>
 </ContentView>

--- a/Chameleon.Core/Views/MiniPlayerView.xaml
+++ b/Chameleon.Core/Views/MiniPlayerView.xaml
@@ -1,0 +1,84 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentView xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Chameleon.Core.Views.MiniPlayerView">
+    <ContentView.Content>
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="1"
+                               x:Name="progressBar" />
+                <RowDefinition Height="auto"
+                               x:Name="mediaInfo" />
+                <RowDefinition Height="35"
+                               x:Name="miniPlayerButtons" />
+                <RowDefinition Height="Auto"
+                               x:Name="divider" />
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="24" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="24" />
+            </Grid.ColumnDefinitions>
+
+            <ProgressBar Grid.ColumnSpan="7"
+                         HorizontalOptions="FillAndExpand"
+                         ProgressColor="#FFF14431"
+                         Progress=".5" />
+            <Label Grid.Row="1"
+                   Grid.ColumnSpan="7"
+                   Margin="0,9"
+                   FontSize="12"
+                   FontAttributes="Bold"
+                   TextColor="White"
+                   HorizontalTextAlignment="Center"
+                   Text="Track Title Artist" />
+            <ImageButton Grid.Row="2"
+                         Grid.Column="1"
+                         HeightRequest="32"
+                         WidthRequest="32"
+                         VerticalOptions="Center"
+                         HorizontalOptions="Center"
+                         BackgroundColor="Transparent"
+                         Source="playback_controls_shuffle_on" />
+            <ImageButton Grid.Row="2"
+                         Grid.Column="2"
+                         HeightRequest="32"
+                         WidthRequest="32"
+                         HorizontalOptions="Center"
+                         VerticalOptions="Center"
+                         BackgroundColor="Transparent"
+                         Source="playback_controls_previous" />
+            <ImageButton Grid.Row="2"
+                         Grid.Column="3"
+                         HeightRequest="35"
+                         WidthRequest="35"
+                         HorizontalOptions="Center"
+                         Source="playback_controls_play_button" />
+            <ImageButton Grid.Row="2"
+                         Grid.Column="4"
+                         HeightRequest="32"
+                         WidthRequest="32"
+                         HorizontalOptions="Center"
+                         VerticalOptions="Center"
+                         BackgroundColor="Transparent"
+                         Source="playback_controls_next" />
+            <ImageButton Grid.Row="2"
+                         Grid.Column="5"
+                         HeightRequest="32"
+                         WidthRequest="32"
+                         HorizontalOptions="Center"
+                         VerticalOptions="Center"
+                         BackgroundColor="Transparent"
+                         Source="icon_more" />
+            <BoxView Grid.Row="3"
+                     Grid.ColumnSpan="7"
+                     Color="Black"
+                     Margin="0,12,0,.5"
+                     HeightRequest=".5"/>
+        </Grid>
+    </ContentView.Content>
+</ContentView>

--- a/Chameleon.Core/Views/MiniPlayerView.xaml
+++ b/Chameleon.Core/Views/MiniPlayerView.xaml
@@ -1,12 +1,14 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<ContentView xmlns:core="clr-namespace:MvvmCross.Forms.Views;assembly=MvvmCross.Forms"
-             xmlns:mvx="clr-namespace:MvvmCross.Forms.Bindings;assembly=MvvmCross.Forms"
-             xmlns="http://xamarin.com/schemas/2014/forms"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:viewModels="clr-namespace:Chameleon.Core.ViewModels;assembly=Chameleon.Core"
-             x:Class="Chameleon.Core.Views.MiniPlayerView">
+<core:MvxContentView xmlns:core="clr-namespace:MvvmCross.Forms.Views;assembly=MvvmCross.Forms"
+                     xmlns:mvx="clr-namespace:MvvmCross.Forms.Bindings;assembly=MvvmCross.Forms"
+                     xmlns="http://xamarin.com/schemas/2014/forms"
+                     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                     xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                     xmlns:viewModels="clr-namespace:Chameleon.Core.ViewModels;assembly=Chameleon.Core"
+                     mc:Ignorable="d"
+                     x:Class="Chameleon.Core.Views.MiniPlayerView">
+
     <ContentView.Content>
         <Grid>
             <Grid.RowDefinitions>
@@ -91,4 +93,4 @@
             </BoxView>
         </Grid>
     </ContentView.Content>
-</ContentView>
+</core:MvxContentView>

--- a/Chameleon.Core/Views/MiniPlayerView.xaml
+++ b/Chameleon.Core/Views/MiniPlayerView.xaml
@@ -6,6 +6,7 @@
                      xmlns:d="http://xamarin.com/schemas/2014/forms/design"
                      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                      xmlns:viewModels="clr-namespace:Chameleon.Core.ViewModels;assembly=Chameleon.Core"
+                     xmlns:controls="clr-namespace:Chameleon.Core.Controls"
                      x:TypeArguments="viewModels:MiniPlayerViewModel"
                      mc:Ignorable="d"
                      x:Class="Chameleon.Core.Views.MiniPlayerView">
@@ -32,57 +33,68 @@
                 <ColumnDefinition Width="24" />
             </Grid.ColumnDefinitions>
 
+            <Grid.GestureRecognizers>
+                <TapGestureRecognizer mvx:Bi.nd="Command OpenPlayerCommand"/>
+            </Grid.GestureRecognizers>
+
             <ProgressBar Grid.ColumnSpan="7"
                          HorizontalOptions="FillAndExpand"
                          ProgressColor="#FFF14431"
                          Progress=".5" />
             <Label Grid.Row="1"
-                   Grid.ColumnSpan="7"
+                   Grid.Column="1"
+                   LineBreakMode="TailTruncation"
+                   Grid.ColumnSpan="5"
                    Margin="0,9"
                    FontSize="12"
                    FontAttributes="Bold"
                    TextColor="White"
                    HorizontalTextAlignment="Center"
-                   Text="Track Title Artist" />
-            <ImageButton Grid.Row="2"
-                         Grid.Column="1"
-                         HeightRequest="32"
-                         WidthRequest="32"
-                         VerticalOptions="Center"
-                         HorizontalOptions="Center"
-                         BackgroundColor="Transparent"
-                         Source="playback_controls_shuffle_on" />
-            <ImageButton Grid.Row="2"
-                         Grid.Column="2"
-                         HeightRequest="32"
-                         WidthRequest="32"
-                         HorizontalOptions="Center"
-                         VerticalOptions="Center"
-                         BackgroundColor="Transparent"
-                         Source="playback_controls_previous" />
-            <ImageButton Grid.Row="2"
-                         Grid.Column="3"
-                         HeightRequest="35"
-                         WidthRequest="35"
-                         HorizontalOptions="Center"
-                         Command="{Binding PlayPauseCommand}"
-                         Source="playback_controls_play_button" />
-            <ImageButton Grid.Row="2"
-                         Grid.Column="4"
-                         HeightRequest="32"
-                         WidthRequest="32"
-                         HorizontalOptions="Center"
-                         VerticalOptions="Center"
-                         BackgroundColor="Transparent"
-                         Source="playback_controls_next" />
-            <ImageButton Grid.Row="2"
-                         Grid.Column="5"
-                         HeightRequest="32"
-                         WidthRequest="32"
-                         HorizontalOptions="Center"
-                         VerticalOptions="Center"
-                         BackgroundColor="Transparent"
-                         Source="icon_more" />
+                   FormattedText="{Binding CurrentMediaItemText}" />
+            <controls:SelectableButton
+                Grid.Row="2"
+                Grid.Column="1"
+                HeightRequest="32"
+                WidthRequest="32"
+                VerticalOptions="Center"
+                HorizontalOptions="Center"
+                BackgroundColor="Transparent"
+                mvx:Bi.nd="Command ShuffleCommand; Source ShuffleImage" />
+            <controls:SelectableButton
+                Grid.Row="2"
+                Grid.Column="2"
+                HorizontalOptions="Center"
+                VerticalOptions="Center"
+                Aspect="AspectFit"
+                BackgroundColor="Transparent"
+                HeightRequest="32"
+                WidthRequest="32"
+                mvx:Bi.nd="Command PreviousCommand"
+                Source="playback_controls_previous" />
+            <controls:SelectableButton
+                Grid.Row="2"
+                Grid.Column="3"
+                VerticalOptions="Center"
+                mvx:Bi.nd="Command PlayPauseCommand; Source PlayPauseImage" />
+            <controls:SelectableButton
+                Grid.Row="2"
+                Grid.Column="4"
+                HeightRequest="32"
+                WidthRequest="32"
+                HorizontalOptions="Center"
+                VerticalOptions="Center"
+                BackgroundColor="Transparent"
+                mvx:Bi.nd="Command NextCommand"
+                Source="playback_controls_next" />
+            <controls:SelectableButton
+                Grid.Row="2"
+                Grid.Column="5"
+                HeightRequest="32"
+                WidthRequest="32"
+                HorizontalOptions="Center"
+                VerticalOptions="Center"
+                BackgroundColor="Transparent"
+                Source="icon_more" />
             <BoxView Grid.Row="3"
                      Grid.ColumnSpan="7"
                      Margin="0,12,0,.5"

--- a/Chameleon.Core/Views/MiniPlayerView.xaml
+++ b/Chameleon.Core/Views/MiniPlayerView.xaml
@@ -83,7 +83,7 @@
                      Grid.ColumnSpan="7"
                      Color="Black"
                      Margin="0,12,0,.5"
-                     HeightRequest=".5" />
+                     HeightRequest=".5"/>
         </Grid>
     </ContentView.Content>
 </ContentView>

--- a/Chameleon.Core/Views/MiniPlayerView.xaml
+++ b/Chameleon.Core/Views/MiniPlayerView.xaml
@@ -1,6 +1,11 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<ContentView xmlns="http://xamarin.com/schemas/2014/forms"
+<ContentView xmlns:core="clr-namespace:MvvmCross.Forms.Views;assembly=MvvmCross.Forms"
+             xmlns:mvx="clr-namespace:MvvmCross.Forms.Bindings;assembly=MvvmCross.Forms"
+             xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:viewModels="clr-namespace:Chameleon.Core.ViewModels;assembly=Chameleon.Core"
              x:Class="Chameleon.Core.Views.MiniPlayerView">
     <ContentView.Content>
         <Grid>
@@ -78,7 +83,7 @@
                      Grid.ColumnSpan="7"
                      Color="Black"
                      Margin="0,12,0,.5"
-                     HeightRequest=".5"/>
+                     HeightRequest=".5" />
         </Grid>
     </ContentView.Content>
 </ContentView>

--- a/Chameleon.Core/Views/MiniPlayerView.xaml
+++ b/Chameleon.Core/Views/MiniPlayerView.xaml
@@ -6,6 +6,7 @@
                      xmlns:d="http://xamarin.com/schemas/2014/forms/design"
                      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                      xmlns:viewModels="clr-namespace:Chameleon.Core.ViewModels;assembly=Chameleon.Core"
+                     xmlns:local="clr-namespace:Chameleon.Core.Helpers"
                      xmlns:controls="clr-namespace:Chameleon.Core.Controls"
                      x:TypeArguments="viewModels:MiniPlayerViewModel"
                      mc:Ignorable="d"
@@ -34,13 +35,13 @@
             </Grid.ColumnDefinitions>
 
             <Grid.GestureRecognizers>
-                <TapGestureRecognizer mvx:Bi.nd="Command OpenPlayerCommand"/>
+                <TapGestureRecognizer mvx:Bi.nd="Command OpenPlayerCommand" />
             </Grid.GestureRecognizers>
 
             <ProgressBar Grid.ColumnSpan="7"
                          HorizontalOptions="FillAndExpand"
                          ProgressColor="#FFF14431"
-                         Progress=".5" />
+                         mvx:Bi.nd="Progress Progress" />
             <Label Grid.Row="1"
                    Grid.Column="1"
                    LineBreakMode="TailTruncation"
@@ -94,6 +95,8 @@
                 HorizontalOptions="Center"
                 VerticalOptions="Center"
                 BackgroundColor="Transparent"
+                Command="{Binding Source={x:Static local:NavigationHelper.OptionsCommand}}"
+                CommandParameter="{Binding CurrentlyPlaying}"
                 Source="icon_more" />
             <BoxView Grid.Row="3"
                      Grid.ColumnSpan="7"

--- a/Chameleon.Core/Views/MiniPlayerView.xaml.cs
+++ b/Chameleon.Core/Views/MiniPlayerView.xaml.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using MvvmCross.Forms.Views;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace Chameleon.Core.Views
 {
     [XamlCompilation(XamlCompilationOptions.Compile)]
-    public partial class MiniPlayerView : ContentView
+    public partial class MiniPlayerView : MvxContentView
     {
         public MiniPlayerView()
         {

--- a/Chameleon.Core/Views/MiniPlayerView.xaml.cs
+++ b/Chameleon.Core/Views/MiniPlayerView.xaml.cs
@@ -1,13 +1,17 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
+using Chameleon.Core.ViewModels;
+using MvvmCross;
 using MvvmCross.Forms.Views;
+using MvvmCross.ViewModels;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace Chameleon.Core.Views
 {
-    [XamlCompilation(XamlCompilationOptions.Compile)]
-    public partial class MiniPlayerView : MvxContentView
+    [DesignTimeVisible(false)]
+    public partial class MiniPlayerView : MvxContentView<MiniPlayerViewModel>
     {
         public MiniPlayerView()
         {

--- a/Chameleon.Core/Views/MiniPlayerView.xaml.cs
+++ b/Chameleon.Core/Views/MiniPlayerView.xaml.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Chameleon.Core.Views
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class MiniPlayerView : ContentView
+    {
+        public MiniPlayerView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Chameleon.Core/Views/PlayerLandscapeView.xaml.cs
+++ b/Chameleon.Core/Views/PlayerLandscapeView.xaml.cs
@@ -4,7 +4,6 @@ using Xamarin.Forms.Xaml;
 
 namespace Chameleon.Core.Views
 {
-    [XamlCompilation(XamlCompilationOptions.Compile)]
     public partial class PlayerLandscapeView : ContentView
     {
         public PlayerLandscapeView()

--- a/Chameleon.Core/Views/PlayerPortraitView.xaml
+++ b/Chameleon.Core/Views/PlayerPortraitView.xaml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<ContentView xmlns="http://xamarin.com/schemas/2014/forms" 
+<ContentView xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:d="http://xamarin.com/schemas/2014/forms/design"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -7,127 +7,128 @@
              xmlns:mm="clr-namespace:MediaManager.Forms;assembly=MediaManager.Forms"
              mc:Ignorable="d"
              x:Class="Chameleon.Core.Views.PlayerPortraitView">
-  <ContentView.Content>
+    <ContentView.Content>
         <Grid
-        ColumnSpacing="0"
-        RowSpacing="0"
-        BackgroundColor="#30313c">
+            ColumnSpacing="0"
+            RowSpacing="0"
+            BackgroundColor="#30313c">
 
             <StackLayout
-            HorizontalOptions="FillAndExpand"
-            VerticalOptions="FillAndExpand"
-            BackgroundColor="#30313c"
-            Padding="0,120,0,120">
+                HorizontalOptions="FillAndExpand"
+                VerticalOptions="FillAndExpand"
+                BackgroundColor="#30313c"
+                Padding="0,120,0,120">
 
                 <mm:VideoView
-            HorizontalOptions="FillAndExpand"
-            VerticalOptions="FillAndExpand"
-            mvx:Bi.nd="Source Source"
-            Margin=" 0,0,0, 280"/>
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="FillAndExpand"
+                    mvx:Bi.nd="Source Source"
+                    Margin=" 0,0,0, 280" />
             </StackLayout>
 
 
             <StackLayout
-            HorizontalOptions="End"
-            VerticalOptions="Start"
-            Padding="20"
-            BackgroundColor="#30313c">
+                HorizontalOptions="End"
+                VerticalOptions="Start"
+                Padding="20"
+                BackgroundColor="#30313c">
 
                 <ImageButton
-                Source="icon_close"
-                mvx:Bi.nd="Command BackCommand"
-                HorizontalOptions="End"
-                VerticalOptions="Start"/>
+                    Source="icon_close"
+                    mvx:Bi.nd="Command BackCommand"
+                    HorizontalOptions="End"
+                    VerticalOptions="Start" />
             </StackLayout>
 
             <StackLayout
-            HorizontalOptions="Start"
-            VerticalOptions="StartAndExpand"
-            Padding="10"
-            BackgroundColor="#30313c">
-
-                <Label Text="Title {Binding Source.DisplayTitle}"
-                FontFamily="FiraSans#600" FontSize="20" 
                 HorizontalOptions="Start"
                 VerticalOptions="StartAndExpand"
-                TextColor="White"/>
+                Padding="10"
+                BackgroundColor="#30313c">
 
-                <Label 
-                Text=" Subtitle {Binding Source.DisplaySubtitle}"
-                FontFamily="FiraSans#400" FontSize="14"
-                HorizontalOptions="Start" 
-                VerticalOptions="StartAndExpand"
-                TextColor="White"/>
+                <Label Text="Title {Binding Source.DisplayTitle}"
+                       FontFamily="FiraSans#600"
+                       FontSize="20"
+                       HorizontalOptions="Start"
+                       VerticalOptions="StartAndExpand"
+                       TextColor="White" />
+
+                <Label
+                    Text=" Subtitle {Binding Source.DisplaySubtitle}"
+                    FontFamily="FiraSans#400"
+                    FontSize="14"
+                    HorizontalOptions="Start"
+                    VerticalOptions="StartAndExpand"
+                    TextColor="White" />
             </StackLayout>
 
             <StackLayout
-            HorizontalOptions="FillAndExpand"
-            VerticalOptions="EndAndExpand"
-            Orientation="Vertical"
-                        BackgroundColor="#30313c"
->
+                HorizontalOptions="FillAndExpand"
+                VerticalOptions="EndAndExpand"
+                Orientation="Vertical"
+                BackgroundColor="#30313c">
 
                 <StackLayout
-            Orientation="Horizontal"
-            HorizontalOptions="FillAndExpand"
-            VerticalOptions="EndAndExpand"
-            BackgroundColor="#30313c"
-            Padding="5"
-            Spacing="15">
+                    Orientation="Horizontal"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="EndAndExpand"
+                    BackgroundColor="#30313c"
+                    Padding="5"
+                    Spacing="15">
 
                     <Slider
-                HorizontalOptions="FillAndExpand"
-                VerticalOptions="Center"
-                mvx:Bi.nd="Value Position; Maximum Duration; DragCompletedCommand DragCompletedCommand"/>
+                        HorizontalOptions="FillAndExpand"
+                        VerticalOptions="Center"
+                        mvx:Bi.nd="Value Position; Maximum Duration; DragCompletedCommand DragCompletedCommand" />
 
-                    <Label Text="{Binding Source.Duration}" 
-                HorizontalOptions="End"
-                VerticalOptions="Center"
-                BackgroundColor="Transparent"
-                TextColor="White"/>
+                    <Label Text="{Binding Source.Duration}"
+                           HorizontalOptions="End"
+                           VerticalOptions="Center"
+                           BackgroundColor="Transparent"
+                           TextColor="White" />
                 </StackLayout>
 
                 <StackLayout
-            Orientation="Horizontal"
-            VerticalOptions="End"
-            HorizontalOptions="FillAndExpand"
-            Padding="10"
-            Spacing="20"
-            BackgroundColor="#30313c">
+                    Orientation="Horizontal"
+                    VerticalOptions="End"
+                    HorizontalOptions="FillAndExpand"
+                    Padding="10"
+                    Spacing="20"
+                    BackgroundColor="#30313c">
 
                     <ImageButton
-                Source="playback_controls_previous"
-                mvx:Bi.nd="Command PreviousCommand"
-                HorizontalOptions="Center"
-                VerticalOptions="CenterAndExpand"/>
+                        Source="playback_controls_previous"
+                        mvx:Bi.nd="Command PreviousCommand"
+                        HorizontalOptions="Center"
+                        VerticalOptions="CenterAndExpand" />
 
                     <ImageButton
-                Source="playback_controls_skip_backwards"
-                mvx:Bi.nd="Command SkipBackwardsCommand"
-                HorizontalOptions="Center"
-                VerticalOptions="CenterAndExpand"
-                BackgroundColor="Transparent"/>
+                        Source="playback_controls_skip_backwards"
+                        mvx:Bi.nd="Command SkipBackwardsCommand"
+                        HorizontalOptions="Center"
+                        VerticalOptions="CenterAndExpand"
+                        BackgroundColor="Transparent" />
 
                     <ImageButton
-                Source="{Binding PlayPauseImage}"
-                mvx:Bi.nd="Command PlayPauseCommand"
-                HorizontalOptions="Center"
-                VerticalOptions="CenterAndExpand"
-                BackgroundColor="Transparent" />
+                        Source="{Binding PlayPauseImage}"
+                        mvx:Bi.nd="Command PlayPauseCommand"
+                        HorizontalOptions="Center"
+                        VerticalOptions="CenterAndExpand"
+                        BackgroundColor="Transparent" />
 
                     <ImageButton
-                Source="playback_controls_skip_forward"
-                mvx:Bi.nd="Command SkipForwardCommand"
-                HorizontalOptions="Center"
-                VerticalOptions="CenterAndExpand"
-                BackgroundColor="Transparent"/>
+                        Source="playback_controls_skip_forward"
+                        mvx:Bi.nd="Command SkipForwardCommand"
+                        HorizontalOptions="Center"
+                        VerticalOptions="CenterAndExpand"
+                        BackgroundColor="Transparent" />
 
                     <ImageButton
-                Source="playback_controls_next"
-                mvx:Bi.nd="Command NextCommand"
-                HorizontalOptions="Center"
-                VerticalOptions="CenterAndExpand"
-                BackgroundColor="Transparent"/>
+                        Source="playback_controls_next"
+                        mvx:Bi.nd="Command NextCommand"
+                        HorizontalOptions="Center"
+                        VerticalOptions="CenterAndExpand"
+                        BackgroundColor="Transparent" />
                 </StackLayout>
             </StackLayout>
         </Grid>

--- a/Chameleon.Core/Views/PlayerPortraitView.xaml.cs
+++ b/Chameleon.Core/Views/PlayerPortraitView.xaml.cs
@@ -4,7 +4,6 @@ using Xamarin.Forms.Xaml;
 
 namespace Chameleon.Core.Views
 {
-    [XamlCompilation(XamlCompilationOptions.Compile)]
     public partial class PlayerPortraitView : ContentView
     {
         public PlayerPortraitView()


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?


### :new: What is the new behavior (if this is a feature change)?
Miniplayer added to homepage:
- progressbar to show mediaitem's progress
- showing currently playing itemtitle + album
- buttons to toggle shufflemode, prev./next item, play/pause, more options
- tapping the miniplayer opens the player

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
CHAM-79

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop
