### PR TITLE
fixed soon text. And fixed hardcoded titles

### DIFF
--- a/Chameleon.Core/Pages/ProvidersPage.xaml
+++ b/Chameleon.Core/Pages/ProvidersPage.xaml
@@ -71,7 +71,7 @@
                             </Grid.RowDefinitions>
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto"/>
-                                <ColumnDefinition Width="50"/>
+                                <ColumnDefinition Width="60"/>
                                 <ColumnDefinition Width="*"/>
                             </Grid.ColumnDefinitions>
                             <Label Text="{Binding Title}"

--- a/Chameleon.Core/Templates/AddToPlaylistItemTemplate.xaml
+++ b/Chameleon.Core/Templates/AddToPlaylistItemTemplate.xaml
@@ -28,12 +28,12 @@
                        HeightRequest="56"
                        WidthRequest="55"/>
             </Frame>
-            <Label Text="Title{mvx:MvxBind Title}"
+            <Label Text="{mvx:MvxBind Title}"
                    Style="{StaticResource TitleText}"
                    VerticalOptions="Center"
                    Grid.Column="1"
                    Grid.Row="0"/>
-            <Label Text="Subtitle {mvx:MvxBind Title}"
+            <Label Text=""
                    Style="{StaticResource MediaItemSubTitle}"
                    VerticalOptions="Center"
                    Grid.Column="1"


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
bug

### :arrow_heading_down: What is the current behavior?
soon text did have not enough space. And hardcoded text in add to playlist

### :new: What is the new behavior (if this is a feature change)?
Text Soon has enough space. Hardcoded text is now binding text.

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [x] Follows style guide lines 
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop
